### PR TITLE
Enlarge gas particle visuals by 150%

### DIFF
--- a/lib/game/modules/gas/gas_unit.dart
+++ b/lib/game/modules/gas/gas_unit.dart
@@ -11,6 +11,7 @@ class GasUnit {
   }
 
   static const defaultVolume = 1.0;
+  static const _visualScale = 1.5;
 
   GasType type;
   Vector2 position;
@@ -65,5 +66,5 @@ class GasUnit {
     _updateRadius();
   }
 
-  void _updateRadius() => _radius = sqrt(_volume / pi);
+  void _updateRadius() => _radius = sqrt(_volume / pi) * _visualScale;
 }


### PR DESCRIPTION
## Summary
- scale gas unit radius by 1.5x for greater visibility

## Testing
- `dart format lib/game/modules/gas/gas_unit.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bd1eff398832da4e72a4347f135a6