### PR TITLE
Make AudioManager a reusable static utility

### DIFF
--- a/lib/game/playing_field.dart
+++ b/lib/game/playing_field.dart
@@ -8,6 +8,7 @@ import 'package:humanity_vs_nature/game/modules/matrix/block_type.dart';
 import 'package:humanity_vs_nature/game/modules/tree/tree_component.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
 import 'package:humanity_vs_nature/generated/assets.dart';
+import 'package:humanity_vs_nature/utils/audio_manager.dart';
 
 class PlayingField extends RectangleComponent
     with HasGameRef<SimulationGame>, TapCallbacks {
@@ -40,7 +41,14 @@ class PlayingField extends RectangleComponent
     if (game.matrix.getBlockTypeAtPosition(tapPosition) == BlockType.tree) {
       game.treeModule.expandForest(tapPosition);
     } else {
-      game.audio.playOnce(Assets.soundsRustlingGrass1, tapPosition);
+      AudioManager.playRandom(
+        [
+          Assets.soundsRustlingGrass1,
+          Assets.soundsRustlingGrass2,
+          Assets.soundsRustlingGrass3,
+        ],
+        tapPosition,
+      );
       _timeForSpawnTree /= 2;
       _preferredPositionForSpawnTree = tapPosition;
     }

--- a/lib/game/simulation_game.dart
+++ b/lib/game/simulation_game.dart
@@ -67,12 +67,17 @@ class SimulationGame extends FlameGame
 
   double timerToLoss = timeToStopCountdown;
 
-  /// Centralised audio controller used by modules to play sound effects.
-  late final AudioManager audio = AudioManager(this);
-
   @override
   FutureOr<void> onLoad() async {
     await Future.delayed(const Duration(seconds: 1));
+
+    AudioManager.initialize(this);
+    await AudioManager.preload([
+      Assets.soundsBulldozer,
+      Assets.soundsRustlingGrass1,
+      Assets.soundsRustlingGrass2,
+      Assets.soundsRustlingGrass3,
+    ]);
 
     spriteCone = await getSpriteFromAsset(Assets.spritesCone);
     spriteMatureTree = await getSpriteFromAsset(Assets.spritesMatureTree);

--- a/lib/utils/audio_manager.dart
+++ b/lib/utils/audio_manager.dart
@@ -1,3 +1,6 @@
+import 'dart:math';
+
+import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame_audio/flame_audio.dart';
 
@@ -7,18 +10,28 @@ import 'package:flame_audio/flame_audio.dart';
 /// automatically adjusted based on the distance from the camera's centre so
 /// that objects near the middle of the screen are louder than those far away.
 class AudioManager {
-  AudioManager(this.game) {
+  AudioManager._();
+
+  static FlameGame? _game;
+  static final Map<String, AudioPlayer> _loopingPlayers = {};
+  static final _random = Random();
+
+  /// Initialises the audio manager with a reference to the [game].
+  ///
+  /// Must be called before any sounds are played.
+  static void initialize(FlameGame game) {
+    _game = game;
     // All game audio files are expected to live under `assets/sounds/`.
     FlameAudio.audioCache.prefix = '';
   }
 
-  final FlameGame game;
-
-  final Map<String, AudioPlayer> _loopingPlayers = {};
-
   /// Calculates volume factor depending on how close [position] is to the
   /// centre of the screen. Returns a value in the 0-1 range.
-  double _volumeFor(Vector2 position) {
+  static double _volumeFor(Vector2 position) {
+    final game = _game;
+    if (game == null) {
+      return 1;
+    }
     final cameraCentre = game.camera.viewport.position;
     final maxDistance = game.size.length; // Distance at which volume becomes 0
     final distance = position.distanceTo(cameraCentre);
@@ -26,19 +39,36 @@ class AudioManager {
     return normalized.clamp(0, 1);
   }
 
+  /// Preloads a list of audio files so that they can be reused later without
+  /// additional loading cost.
+  static Future<void> preload(List<String> fileNames) async {
+    await FlameAudio.audioCache.loadAll(fileNames);
+  }
+
   /// Plays a single sound effect located at [fileName]. The [position] decides
   /// how loud the sound should be depending on its distance to the screen
   /// centre. Optional [baseVolume] can be used to further tune the volume.
-  Future<void> playOnce(String fileName, Vector2 position,
+  static Future<void> playOnce(String fileName, Vector2 position,
       {double baseVolume = 1}) async {
     final volume = _volumeFor(position) * baseVolume;
     await FlameAudio.play(fileName, volume: volume);
   }
 
+  /// Plays a random sound from [fileNames].
+  static Future<void> playRandom(
+    List<String> fileNames,
+    Vector2 position, {
+    double baseVolume = 1,
+  }) async {
+    if (fileNames.isEmpty) return;
+    final choice = fileNames[_random.nextInt(fileNames.length)];
+    await playOnce(choice, position, baseVolume: baseVolume);
+  }
+
   /// Starts playing a looping sound. The sound is identified by [key] so that
   /// its volume can be updated or it can be stopped later. The [position]
   /// defines the initial volume.
-  Future<void> playLoop(String key, String fileName, Vector2 position,
+  static Future<void> playLoop(String key, String fileName, Vector2 position,
       {double baseVolume = 1}) async {
     final volume = _volumeFor(position) * baseVolume;
     final player = await FlameAudio.loop(fileName, volume: volume);
@@ -46,7 +76,8 @@ class AudioManager {
   }
 
   /// Updates volume for a previously started looping sound.
-  void updateLoop(String key, Vector2 position, {double baseVolume = 1}) {
+  static void updateLoop(String key, Vector2 position,
+      {double baseVolume = 1}) {
     final player = _loopingPlayers[key];
     if (player == null) return;
     final volume = _volumeFor(position) * baseVolume;
@@ -54,7 +85,7 @@ class AudioManager {
   }
 
   /// Stops and removes a looping sound identified by [key].
-  Future<void> stopLoop(String key) async {
+  static Future<void> stopLoop(String key) async {
     final player = _loopingPlayers.remove(key);
     await player?.stop();
   }


### PR DESCRIPTION
## Summary
- Refactor `AudioManager` into a static class with initialization, preloading, random sound selection, and loop control
- Initialize and preload audio assets in `SimulationGame`
- Use random grass rustling sounds via `AudioManager.playRandom` in `PlayingField`

## Testing
- `dart format lib/utils/audio_manager.dart lib/game/playing_field.dart lib/game/simulation_game.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dbd5781b4832da2d5b927ef86d735