### PR TITLE
Refactor sprite handling into static loader

### DIFF
--- a/lib/game/modules/bulldozer/bulldozer_component.dart
+++ b/lib/game/modules/bulldozer/bulldozer_component.dart
@@ -10,6 +10,7 @@ import 'package:humanity_vs_nature/game/mixins/vehicle.dart';
 import 'package:humanity_vs_nature/game/modules/city/city_component.dart';
 import 'package:humanity_vs_nature/game/modules/tree/tree_component.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
+import 'package:humanity_vs_nature/utils/game_sprites.dart';
 
 class BulldozerComponent extends SpriteComponent
     with
@@ -38,7 +39,7 @@ class BulldozerComponent extends SpriteComponent
 
   @override
   FutureOr<void> onLoad() async {
-    sprite = game.spriteBulldozer1;
+    sprite = GameSprites.bulldozer1;
     size *= 0.5;
     anchor = Anchor.center;
     add(CircleHitbox(radius: radius));

--- a/lib/game/modules/city/city_component.dart
+++ b/lib/game/modules/city/city_component.dart
@@ -16,6 +16,7 @@ import 'package:humanity_vs_nature/game/modules/field/field_component.dart';
 import 'package:humanity_vs_nature/game/modules/tutorial/base_tutorial.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
 import 'package:humanity_vs_nature/utils/styles.dart';
+import 'package:humanity_vs_nature/utils/game_sprites.dart';
 
 class CityComponent extends SpriteComponent
     with TapCallbacks, HasGameRef<SimulationGame>, AnimationOnTap, BlinkEffect {
@@ -70,7 +71,7 @@ class CityComponent extends SpriteComponent
 
   @override
   FutureOr<void> onLoad() async {
-    sprite = game.spriteCity;
+    sprite = GameSprites.city;
     anchor = Anchor.center;
     size *= 0.5;
 

--- a/lib/game/modules/combine/combine_component.dart
+++ b/lib/game/modules/combine/combine_component.dart
@@ -7,6 +7,7 @@ import 'package:humanity_vs_nature/game/mixins/animation_on_tap.dart';
 import 'package:humanity_vs_nature/game/mixins/vehicle.dart';
 import 'package:humanity_vs_nature/game/modules/city/city_component.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
+import 'package:humanity_vs_nature/utils/game_sprites.dart';
 
 class CombineComponent extends SpriteComponent
     with Vehicle, TapCallbacks, HasGameRef<SimulationGame>, AnimationOnTap {
@@ -27,7 +28,7 @@ class CombineComponent extends SpriteComponent
 
   @override
   FutureOr<void> onLoad() async {
-    sprite = game.spriteBulldozer2;
+    sprite = GameSprites.bulldozer2;
     size *= 0.5;
     anchor = Anchor.center;
     return super.onLoad();

--- a/lib/game/modules/farm/farm_component.dart
+++ b/lib/game/modules/farm/farm_component.dart
@@ -9,6 +9,7 @@ import 'package:humanity_vs_nature/game/modules/city/city_component.dart';
 import 'package:humanity_vs_nature/game/modules/farm/farm_expand_result.dart';
 import 'package:humanity_vs_nature/game/modules/field/field_component.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
+import 'package:humanity_vs_nature/utils/game_sprites.dart';
 
 class FarmComponent extends SpriteComponent
     with TapCallbacks, HasGameRef<SimulationGame>, AnimationOnTap, BlinkEffect {
@@ -37,7 +38,7 @@ class FarmComponent extends SpriteComponent
 
   @override
   FutureOr<void> onLoad() async {
-    sprite = game.spriteFarm;
+    sprite = GameSprites.farm;
     anchor = Anchor.bottomCenter;
     size *= 0.5;
     return super.onLoad();

--- a/lib/game/modules/tree/tree_component.dart
+++ b/lib/game/modules/tree/tree_component.dart
@@ -8,6 +8,7 @@ import 'package:humanity_vs_nature/game/mixins/blink_mixin.dart';
 import 'package:humanity_vs_nature/game/models/spot.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
 import 'package:humanity_vs_nature/generated/assets.dart';
+import 'package:humanity_vs_nature/utils/game_sprites.dart';
 
 class TreeComponent extends SpriteComponent
     with TapCallbacks, HasGameRef<SimulationGame>, BlinkEffect {
@@ -75,14 +76,14 @@ class TreeComponent extends SpriteComponent
     needCO2toNextPhase = _phase.volumeCO2toNextPhase;
     switch (_phase) {
       case _TreePhase.cone:
-        sprite = game.spriteCone;
-        size = game.spriteCone.originalSize * 0.2;
+        sprite = GameSprites.cone;
+        size = GameSprites.cone.originalSize * 0.2;
       case _TreePhase.young:
-        sprite = game.spriteYoungTree;
-        size = game.spriteYoungTree.originalSize * 0.5;
+        sprite = GameSprites.youngTree;
+        size = GameSprites.youngTree.originalSize * 0.5;
       case _TreePhase.mature:
-        sprite = game.spriteMatureTree;
-        size = game.spriteMatureTree.originalSize * 0.5;
+        sprite = GameSprites.matureTree;
+        size = GameSprites.matureTree.originalSize * 0.5;
     }
   }
 

--- a/lib/game/simulation_game.dart
+++ b/lib/game/simulation_game.dart
@@ -26,7 +26,7 @@ import 'package:humanity_vs_nature/pages/overlays/game_interface_overlay.dart';
 import 'package:humanity_vs_nature/pages/overlays/lost_overlay.dart';
 import 'package:humanity_vs_nature/pages/overlays/win_overlay.dart';
 import 'package:humanity_vs_nature/utils/audio_manager.dart';
-import 'package:humanity_vs_nature/utils/sprite_utils.dart';
+import 'package:humanity_vs_nature/utils/game_sprites.dart';
 
 class SimulationGame extends FlameGame
     with HasCollisionDetection, TapCallbacks, DragCallbacks, ScaleDetector {
@@ -40,13 +40,6 @@ class SimulationGame extends FlameGame
 
   late final S strings;
 
-  late final Sprite spriteCone;
-  late final Sprite spriteYoungTree;
-  late final Sprite spriteMatureTree;
-  late final Sprite spriteFarm;
-  late final Sprite spriteCity;
-  late final Sprite spriteBulldozer1;
-  late final Sprite spriteBulldozer2;
 
   final playingField = PlayingField();
   final tutorial = TutorialModule();
@@ -79,13 +72,7 @@ class SimulationGame extends FlameGame
       Assets.soundsRustlingGrass3,
     ]);
 
-    spriteCone = await getSpriteFromAsset(Assets.spritesCone);
-    spriteMatureTree = await getSpriteFromAsset(Assets.spritesMatureTree);
-    spriteYoungTree = await getSpriteFromAsset(Assets.spritesYoungTree);
-    spriteFarm = await getSpriteFromAsset(Assets.spritesFarm);
-    spriteCity = await getSpriteFromAsset(Assets.spritesCity);
-    spriteBulldozer1 = await getSpriteFromAsset(Assets.spritesBulldozer1);
-    spriteBulldozer2 = await getSpriteFromAsset(Assets.spritesBulldozer2);
+    await GameSprites.load();
 
     matrix = BlocksMatrix(worldSize);
 

--- a/lib/utils/game_sprites.dart
+++ b/lib/utils/game_sprites.dart
@@ -1,0 +1,26 @@
+import 'package:flame/components.dart';
+import 'package:humanity_vs_nature/generated/assets.dart';
+import 'package:humanity_vs_nature/utils/sprite_utils.dart';
+
+class GameSprites {
+  GameSprites._();
+
+  static late final Sprite cone;
+  static late final Sprite youngTree;
+  static late final Sprite matureTree;
+  static late final Sprite farm;
+  static late final Sprite city;
+  static late final Sprite bulldozer1;
+  static late final Sprite bulldozer2;
+
+  static Future<void> load() async {
+    cone = await getSpriteFromAsset(Assets.spritesCone);
+    youngTree = await getSpriteFromAsset(Assets.spritesYoungTree);
+    matureTree = await getSpriteFromAsset(Assets.spritesMatureTree);
+    farm = await getSpriteFromAsset(Assets.spritesFarm);
+    city = await getSpriteFromAsset(Assets.spritesCity);
+    bulldozer1 = await getSpriteFromAsset(Assets.spritesBulldozer1);
+    bulldozer2 = await getSpriteFromAsset(Assets.spritesBulldozer2);
+  }
+}
+


### PR DESCRIPTION
## Summary
- extract predefined sprites into static `GameSprites` class
- load sprites once in `SimulationGame` and reuse across components

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dde1f49c8832dafafa80998eb703c