### PR TITLE
Add GameSounds helper for randomized audio

### DIFF
--- a/lib/game/playing_field.dart
+++ b/lib/game/playing_field.dart
@@ -7,8 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:humanity_vs_nature/game/modules/matrix/block_type.dart';
 import 'package:humanity_vs_nature/game/modules/tree/tree_component.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
-import 'package:humanity_vs_nature/generated/assets.dart';
 import 'package:humanity_vs_nature/utils/audio_manager.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 
 class PlayingField extends RectangleComponent
     with HasGameRef<SimulationGame>, TapCallbacks {
@@ -41,12 +41,8 @@ class PlayingField extends RectangleComponent
     if (game.matrix.getBlockTypeAtPosition(tapPosition) == BlockType.tree) {
       game.treeModule.expandForest(tapPosition);
     } else {
-      AudioManager.playRandom(
-        [
-          Assets.soundsRustlingGrass1,
-          Assets.soundsRustlingGrass2,
-          Assets.soundsRustlingGrass3,
-        ],
+      AudioManager.playOnce(
+        GameSounds.rustlingGrass(),
         tapPosition,
       );
       _timeForSpawnTree /= 2;

--- a/lib/game/simulation_game.dart
+++ b/lib/game/simulation_game.dart
@@ -20,13 +20,13 @@ import 'package:humanity_vs_nature/game/modules/matrix/blocks_matrix.dart';
 import 'package:humanity_vs_nature/game/modules/tree/tree_module.dart';
 import 'package:humanity_vs_nature/game/modules/tutorial/tutorial_module.dart';
 import 'package:humanity_vs_nature/game/playing_field.dart';
-import 'package:humanity_vs_nature/generated/assets.dart';
 import 'package:humanity_vs_nature/generated/l10n.dart';
 import 'package:humanity_vs_nature/pages/overlays/game_interface_overlay.dart';
 import 'package:humanity_vs_nature/pages/overlays/lost_overlay.dart';
 import 'package:humanity_vs_nature/pages/overlays/win_overlay.dart';
 import 'package:humanity_vs_nature/utils/audio_manager.dart';
 import 'package:humanity_vs_nature/utils/game_sprites.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 
 class SimulationGame extends FlameGame
     with HasCollisionDetection, TapCallbacks, DragCallbacks, ScaleDetector {
@@ -65,13 +65,7 @@ class SimulationGame extends FlameGame
     await Future.delayed(const Duration(seconds: 1));
 
     AudioManager.initialize(this);
-    await AudioManager.preload([
-      Assets.soundsBulldozer,
-      Assets.soundsRustlingGrass1,
-      Assets.soundsRustlingGrass2,
-      Assets.soundsRustlingGrass3,
-    ]);
-
+    await GameSounds.load();
     await GameSprites.load();
 
     matrix = BlocksMatrix(worldSize);

--- a/lib/utils/game_sounds.dart
+++ b/lib/utils/game_sounds.dart
@@ -1,0 +1,29 @@
+import 'dart:math';
+
+import 'package:humanity_vs_nature/generated/assets.dart';
+import 'package:humanity_vs_nature/utils/audio_manager.dart';
+
+class GameSounds {
+  GameSounds._();
+
+  static const String bulldozer = Assets.soundsBulldozer;
+
+  static const List<String> _rustlingGrassOptions = [
+    Assets.soundsRustlingGrass1,
+    Assets.soundsRustlingGrass2,
+    Assets.soundsRustlingGrass3,
+  ];
+
+  static final Random _random = Random();
+
+  static Future<void> load() async {
+    await AudioManager.preload([
+      bulldozer,
+      ..._rustlingGrassOptions,
+    ]);
+  }
+
+  static String rustlingGrass() {
+    return _rustlingGrassOptions[_random.nextInt(_rustlingGrassOptions.length)];
+  }
+}


### PR DESCRIPTION
## Summary
- create `GameSounds` static class to preload assets and provide random sound access
- use `GameSounds` for grass rustling effect
- simplify game initialization with `GameSounds.load`

## Testing
- `dart format lib/utils/game_sounds.dart lib/game/playing_field.dart lib/game/simulation_game.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dea361efc832dbeb0e3fa913c92d2