### PR TITLE
Wire GameSounds into gameplay events

### DIFF
--- a/lib/game/modules/bulldozer/bulldozer_component.dart
+++ b/lib/game/modules/bulldozer/bulldozer_component.dart
@@ -10,6 +10,7 @@ import 'package:humanity_vs_nature/game/mixins/vehicle.dart';
 import 'package:humanity_vs_nature/game/modules/city/city_component.dart';
 import 'package:humanity_vs_nature/game/modules/tree/tree_component.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 import 'package:humanity_vs_nature/utils/game_sprites.dart';
 
 class BulldozerComponent extends SpriteComponent
@@ -77,6 +78,7 @@ class BulldozerComponent extends SpriteComponent
     } else {
       goHome();
     }
+
   }
 
   void goHome() {
@@ -106,6 +108,10 @@ class BulldozerComponent extends SpriteComponent
   @override
   void onTapUp(TapUpEvent event) {
     super.onTapUp(event);
+    AudioManager.play(
+      GameSounds.bulldozerTapped(),
+      position: event.canvasPosition,
+    );
     hp -= 1;
     if (hp < 1) game.bulldozerModule.removeBulldozer(this);
     animateOnTap();

--- a/lib/game/modules/bulldozer/bulldozer_module.dart
+++ b/lib/game/modules/bulldozer/bulldozer_module.dart
@@ -3,6 +3,7 @@ import 'package:humanity_vs_nature/game/modules/bulldozer/bulldozer_component.da
 import 'package:humanity_vs_nature/game/modules/city/city_component.dart';
 import 'package:humanity_vs_nature/game/modules/tree/tree_component.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 
 class BulldozerModule extends Component with HasGameRef<SimulationGame> {
   final List<BulldozerComponent> bulldozers = [];
@@ -14,10 +15,18 @@ class BulldozerModule extends Component with HasGameRef<SimulationGame> {
       ..targetTree = target;
     bulldozers.add(bulldozer);
     add(bulldozer);
+    AudioManager.play(
+      GameSounds.bulldozerSpawned(),
+      position: owner.position,
+    );
     return bulldozer;
   }
 
   void removeBulldozer(BulldozerComponent bulldozer) {
+    AudioManager.play(
+      GameSounds.bulldozerDestroyed(),
+      position: bulldozer.position,
+    );
     remove(bulldozer);
     bulldozer.city.bulldozers.remove(bulldozer);
     bulldozers.remove(bulldozer);

--- a/lib/game/modules/city/city_component.dart
+++ b/lib/game/modules/city/city_component.dart
@@ -15,6 +15,7 @@ import 'package:humanity_vs_nature/game/modules/farm/farm_expand_result.dart';
 import 'package:humanity_vs_nature/game/modules/field/field_component.dart';
 import 'package:humanity_vs_nature/game/modules/tutorial/base_tutorial.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 import 'package:humanity_vs_nature/utils/game_sprites.dart';
 import 'package:humanity_vs_nature/utils/styles.dart';
 
@@ -145,6 +146,10 @@ class CityComponent extends SpriteComponent
   @override
   void onTapUp(TapUpEvent event) {
     super.onTapUp(event);
+    AudioManager.play(
+      GameSounds.cityTapped(),
+      position: event.canvasPosition,
+    );
     awareness += 0.001;
     if (awareness > 1) awareness = 1;
     textAwarenessValue.text = '${(awareness * 100).round()}';

--- a/lib/game/modules/farm/farm_component.dart
+++ b/lib/game/modules/farm/farm_component.dart
@@ -9,6 +9,7 @@ import 'package:humanity_vs_nature/game/modules/city/city_component.dart';
 import 'package:humanity_vs_nature/game/modules/farm/farm_expand_result.dart';
 import 'package:humanity_vs_nature/game/modules/field/field_component.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 import 'package:humanity_vs_nature/utils/game_sprites.dart';
 
 class FarmComponent extends SpriteComponent
@@ -120,6 +121,10 @@ class FarmComponent extends SpriteComponent
   @override
   void onTapUp(TapUpEvent event) {
     super.onTapUp(event);
+    AudioManager.play(
+      GameSounds.farmTapped(),
+      position: event.canvasPosition,
+    );
     hp -= 1;
     if (hp < 1) {
       game.farmModule.removeFarm(this);

--- a/lib/game/modules/farm/farm_module.dart
+++ b/lib/game/modules/farm/farm_module.dart
@@ -4,6 +4,7 @@ import 'package:humanity_vs_nature/game/modules/city/city_component.dart';
 import 'package:humanity_vs_nature/game/modules/farm/farm_component.dart';
 import 'package:humanity_vs_nature/game/modules/matrix/block_type.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 
 class FarmModule extends Component with HasGameRef<SimulationGame> {
   final List<FarmComponent> farms = [];
@@ -34,11 +35,19 @@ class FarmModule extends Component with HasGameRef<SimulationGame> {
     add(farm);
     farm.baseField = game.fieldModule.addFirstFieldForFarm(farm);
     game.fieldModule.removeAllOtherFieldsInTheFieldArea(farm.baseField);
+    AudioManager.play(
+      GameSounds.farmSpawned(),
+      position: position,
+    );
     return farm;
     //TODO remove all trees too
   }
 
   void removeFarm(FarmComponent farm) {
+    AudioManager.play(
+      GameSounds.farmDestroyed(),
+      position: farm.position,
+    );
     remove(farm);
     farms.remove(farm);
     farm.owner.farms.remove(farm);

--- a/lib/game/modules/field/field_module.dart
+++ b/lib/game/modules/field/field_module.dart
@@ -11,6 +11,7 @@ import 'package:humanity_vs_nature/game/modules/farm/farm_component.dart';
 import 'package:humanity_vs_nature/game/modules/field/field_component.dart';
 import 'package:humanity_vs_nature/game/modules/matrix/block_type.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 
 class FieldModule extends Component with HasGameRef<SimulationGame> {
   static const double maxFieldClearanceTime = 5;
@@ -86,6 +87,10 @@ class FieldModule extends Component with HasGameRef<SimulationGame> {
     fields.add(field);
     add(field);
     game.matrix.markBlocksForField(field);
+    AudioManager.play(
+      GameSounds.fieldSpawned(),
+      position: field.position + field.size / 2,
+    );
     return field;
   }
 

--- a/lib/game/modules/tree/tree_component.dart
+++ b/lib/game/modules/tree/tree_component.dart
@@ -8,6 +8,7 @@ import 'package:humanity_vs_nature/game/mixins/blink_mixin.dart';
 import 'package:humanity_vs_nature/game/models/spot.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
 import 'package:humanity_vs_nature/generated/assets.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 import 'package:humanity_vs_nature/utils/game_sprites.dart';
 
 class TreeComponent extends SpriteComponent
@@ -59,8 +60,16 @@ class TreeComponent extends SpriteComponent
         // Grow up to next phase
         if (_phase == _TreePhase.cone) {
           _phase = _TreePhase.young;
+          AudioManager.play(
+            GameSounds.treeGrown(),
+            position: position,
+          );
         } else {
           _phase = _TreePhase.mature;
+          AudioManager.play(
+            GameSounds.treeGrown(),
+            position: position,
+          );
           final saplingCount = randomFallback.nextInt(3);
           for (var i = 0; i < saplingCount; i++) {
             game.treeModule.expandForest(position);
@@ -90,6 +99,10 @@ class TreeComponent extends SpriteComponent
   @override
   void onTapDown(TapDownEvent event) {
     super.onTapDown(event);
+    AudioManager.play(
+      GameSounds.treeTapped(),
+      position: event.canvasPosition,
+    );
     game.treeModule.expandForest(position);
   }
 

--- a/lib/game/modules/tree/tree_module.dart
+++ b/lib/game/modules/tree/tree_module.dart
@@ -6,6 +6,7 @@ import 'package:humanity_vs_nature/game/models/spot.dart';
 import 'package:humanity_vs_nature/game/modules/matrix/block_type.dart';
 import 'package:humanity_vs_nature/game/modules/tree/tree_component.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 
 class TreeModule extends Component with HasGameRef<SimulationGame> {
   final List<TreeComponent> trees = [];
@@ -65,9 +66,17 @@ class TreeModule extends Component with HasGameRef<SimulationGame> {
     add(tree);
     game.matrix.markBlocksForSpot(tree.spot, BlockType.tree);
     updateTopmostTree(tree);
+    AudioManager.play(
+      isMature ? GameSounds.treeSpawned() : GameSounds.coneSpawned(),
+      position: position,
+    );
   }
 
   void removeTree(TreeComponent tree) {
+    AudioManager.play(
+      GameSounds.treeDestroyed(),
+      position: tree.position,
+    );
     remove(tree);
     trees.remove(tree);
     game.matrix.markBlocksForSpot(tree.spot, BlockType.empty);

--- a/lib/game/modules/tutorial/tutorial_module.dart
+++ b/lib/game/modules/tutorial/tutorial_module.dart
@@ -17,6 +17,7 @@ import 'package:humanity_vs_nature/game/simulation_game.dart';
 import 'package:humanity_vs_nature/pages/overlays/tutorial_overlay.dart';
 import 'package:humanity_vs_nature/pages/overlays/tutorials_list_overlay.dart';
 import 'package:humanity_vs_nature/utils/prefs.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 
 class TutorialModule extends Component with HasGameRef<SimulationGame> {
   late final unShownTutorials = <BaseTutorial>[
@@ -71,6 +72,10 @@ class TutorialModule extends Component with HasGameRef<SimulationGame> {
 
   void showTutorial(BaseTutorial tutorial) {
     showingTutorial = tutorial;
+    AudioManager.play(
+      GameSounds.tutorialShown(),
+      position: game.camera.viewport.position,
+    );
     game
       ..overlays.add(TutorialOverlay.overlayName)
       ..setCameraBounds(tutorialBounds: true);

--- a/lib/game/playing_field.dart
+++ b/lib/game/playing_field.dart
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 import 'package:humanity_vs_nature/game/modules/matrix/block_type.dart';
 import 'package:humanity_vs_nature/game/modules/tree/tree_component.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
-import 'package:humanity_vs_nature/utils/audio_manager.dart';
 import 'package:humanity_vs_nature/utils/game_sounds.dart';
 
 class PlayingField extends RectangleComponent
@@ -43,7 +42,7 @@ class PlayingField extends RectangleComponent
     } else {
       AudioManager.play(
         GameSounds.grassTapped(),
-        tapPosition,
+        position: tapPosition,
       );
       _timeForSpawnTree /= 2;
       _preferredPositionForSpawnTree = tapPosition;

--- a/lib/game/simulation_game.dart
+++ b/lib/game/simulation_game.dart
@@ -24,7 +24,6 @@ import 'package:humanity_vs_nature/generated/l10n.dart';
 import 'package:humanity_vs_nature/pages/overlays/game_interface_overlay.dart';
 import 'package:humanity_vs_nature/pages/overlays/lost_overlay.dart';
 import 'package:humanity_vs_nature/pages/overlays/win_overlay.dart';
-import 'package:humanity_vs_nature/utils/audio_manager.dart';
 import 'package:humanity_vs_nature/utils/game_sounds.dart';
 import 'package:humanity_vs_nature/utils/game_sprites.dart';
 

--- a/lib/pages/main_menu_page.dart
+++ b/lib/pages/main_menu_page.dart
@@ -6,6 +6,7 @@ import 'package:humanity_vs_nature/utils/prefs.dart';
 import 'package:humanity_vs_nature/utils/styles.dart';
 import 'package:humanity_vs_nature/widgets/language_selector.dart';
 import 'package:humanity_vs_nature/widgets/pretty_menu_line.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 
 class MainMenuPage extends StatefulWidget {
   const MainMenuPage({
@@ -90,8 +91,12 @@ class _MainMenuPageState extends State<MainMenuPage> {
 
                 /// Start button
                 ElevatedButton(
-                  onPressed: () =>
-                      context.pushNamedAndRemoveAll(GamePage.routeName),
+                  onPressed: () {
+                    AudioManager.play(
+                      GameSounds.buttonTapped(),
+                    );
+                    context.pushNamedAndRemoveAll(GamePage.routeName);
+                  },
                   child: Text(S.current.start),
                 ),
                 const SizedBox(height: 22),
@@ -106,9 +111,14 @@ class _MainMenuPageState extends State<MainMenuPage> {
                 const SizedBox(height: 2),
 
                 ElevatedButton(
-                  onPressed: () => setState(
-                    () => Prefs.tutorialEnabled = !Prefs.tutorialEnabled,
-                  ),
+                  onPressed: () {
+                    AudioManager.play(
+                      GameSounds.buttonTapped(),
+                    );
+                    setState(
+                      () => Prefs.tutorialEnabled = !Prefs.tutorialEnabled,
+                    );
+                  },
                   child: Text(
                     tutorialEnabled
                         ? context.strings.disable

--- a/lib/pages/overlays/game_interface_overlay.dart
+++ b/lib/pages/overlays/game_interface_overlay.dart
@@ -4,6 +4,7 @@ import 'package:humanity_vs_nature/game/modules/tutorial/base_tutorial.dart';
 import 'package:humanity_vs_nature/game/simulation_game.dart';
 import 'package:humanity_vs_nature/pages/overlays/pause_menu_overlay.dart';
 import 'package:humanity_vs_nature/utils/styles.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 
 class GameInterfaceOverlay extends StatelessWidget {
   const GameInterfaceOverlay({
@@ -198,6 +199,9 @@ class GameInterfaceOverlay extends StatelessWidget {
   }
 
   void _onPauseTap() {
+    AudioManager.play(
+      GameSounds.buttonTapped(),
+    );
     game.paused = true;
     game.overlays.add(PauseMenuOverlay.overlayName);
   }

--- a/lib/pages/overlays/lost_overlay.dart
+++ b/lib/pages/overlays/lost_overlay.dart
@@ -5,6 +5,7 @@ import 'package:humanity_vs_nature/pages/main_menu_page.dart';
 import 'package:humanity_vs_nature/utils/styles.dart';
 import 'package:humanity_vs_nature/widgets/pause_background.dart';
 import 'package:humanity_vs_nature/widgets/tutorial_window.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 
 class LostOverlay extends StatelessWidget {
   const LostOverlay({super.key});
@@ -19,13 +20,22 @@ class LostOverlay extends StatelessWidget {
         height: 400,
         buttons: [
           ElevatedButton(
-            onPressed: () =>
-                context.pushNamedAndRemoveAll(MainMenuPage.routeName),
+            onPressed: () {
+              AudioManager.play(
+                GameSounds.buttonTapped(),
+              );
+              context.pushNamedAndRemoveAll(MainMenuPage.routeName);
+            },
             child: Text(context.strings.mainMenu),
           ),
           const SizedBox(height: 10),
           ElevatedButton(
-            onPressed: () => context.pushNamedAndRemoveAll(GamePage.routeName),
+            onPressed: () {
+              AudioManager.play(
+                GameSounds.buttonTapped(),
+              );
+              context.pushNamedAndRemoveAll(GamePage.routeName);
+            },
             child: Text(context.strings.playAgain),
           ),
         ],

--- a/lib/pages/overlays/pause_menu_overlay.dart
+++ b/lib/pages/overlays/pause_menu_overlay.dart
@@ -5,6 +5,7 @@ import 'package:humanity_vs_nature/pages/main_menu_page.dart';
 import 'package:humanity_vs_nature/pages/overlays/tutorials_list_overlay.dart';
 import 'package:humanity_vs_nature/widgets/pause_background.dart';
 import 'package:humanity_vs_nature/widgets/pretty_menu_line.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 
 class PauseMenuOverlay extends StatelessWidget {
   const PauseMenuOverlay({
@@ -36,8 +37,12 @@ class PauseMenuOverlay extends StatelessWidget {
             ),
             const SizedBox(height: 80),
             ElevatedButton(
-              onPressed: () =>
-                  context.pushNamedAndRemoveAll(MainMenuPage.routeName),
+              onPressed: () {
+                AudioManager.play(
+                  GameSounds.buttonTapped(),
+                );
+                context.pushNamedAndRemoveAll(MainMenuPage.routeName);
+              },
               child: Text(context.strings.mainMenu),
             ),
           ],
@@ -47,11 +52,17 @@ class PauseMenuOverlay extends StatelessWidget {
   }
 
   void _onResumeTap() {
+    AudioManager.play(
+      GameSounds.buttonTapped(),
+    );
     game.paused = false;
     game.overlays.remove(overlayName);
   }
 
   void _onTutorialsTap() {
+    AudioManager.play(
+      GameSounds.buttonTapped(),
+    );
     game.overlays.remove(overlayName);
     game.overlays.add(TutorialsListOverlay.overlayName);
   }

--- a/lib/pages/overlays/tutorial_overlay.dart
+++ b/lib/pages/overlays/tutorial_overlay.dart
@@ -6,6 +6,7 @@ import 'package:humanity_vs_nature/game/simulation_game.dart';
 import 'package:humanity_vs_nature/utils/styles.dart';
 import 'package:humanity_vs_nature/widgets/tutorial_background.dart';
 import 'package:humanity_vs_nature/widgets/tutorial_window.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 
 class TutorialOverlay extends StatelessWidget {
   const TutorialOverlay({
@@ -77,5 +78,10 @@ class TutorialOverlay extends StatelessWidget {
     );
   }
 
-  void _onGotItTap() => game.tutorial.closeTutorial();
+  void _onGotItTap() {
+    AudioManager.play(
+      GameSounds.buttonTapped(),
+    );
+    game.tutorial.closeTutorial();
+  }
 }

--- a/lib/pages/overlays/tutorials_list_overlay.dart
+++ b/lib/pages/overlays/tutorials_list_overlay.dart
@@ -16,6 +16,7 @@ import 'package:humanity_vs_nature/pages/overlays/tutorial_overlay.dart';
 import 'package:humanity_vs_nature/utils/styles.dart';
 import 'package:humanity_vs_nature/widgets/pause_background.dart';
 import 'package:humanity_vs_nature/widgets/pretty_menu_line.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 
 class TutorialsListOverlay extends StatelessWidget {
   const TutorialsListOverlay({
@@ -84,6 +85,9 @@ class TutorialsListOverlay extends StatelessWidget {
   }
 
   void _popAndShowTutorial(BaseTutorial tutorial) {
+    AudioManager.play(
+      GameSounds.buttonTapped(),
+    );
     game.overlays.remove(overlayName);
     game.paused = false;
 
@@ -95,6 +99,9 @@ class TutorialsListOverlay extends StatelessWidget {
   }
 
   void _onResumeTap() {
+    AudioManager.play(
+      GameSounds.buttonTapped(),
+    );
     game.paused = false;
     game.overlays.remove(overlayName);
   }

--- a/lib/pages/overlays/win_overlay.dart
+++ b/lib/pages/overlays/win_overlay.dart
@@ -5,6 +5,7 @@ import 'package:humanity_vs_nature/pages/main_menu_page.dart';
 import 'package:humanity_vs_nature/utils/styles.dart';
 import 'package:humanity_vs_nature/widgets/pause_background.dart';
 import 'package:humanity_vs_nature/widgets/tutorial_window.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 
 class WinOverlay extends StatelessWidget {
   const WinOverlay({super.key});
@@ -19,13 +20,22 @@ class WinOverlay extends StatelessWidget {
         height: 400,
         buttons: [
           ElevatedButton(
-            onPressed: () =>
-                context.pushNamedAndRemoveAll(MainMenuPage.routeName),
+            onPressed: () {
+              AudioManager.play(
+                GameSounds.buttonTapped(),
+              );
+              context.pushNamedAndRemoveAll(MainMenuPage.routeName);
+            },
             child: Text(context.strings.mainMenu),
           ),
           const SizedBox(height: 10),
           ElevatedButton(
-            onPressed: () => context.pushNamedAndRemoveAll(GamePage.routeName),
+            onPressed: () {
+              AudioManager.play(
+                GameSounds.buttonTapped(),
+              );
+              context.pushNamedAndRemoveAll(GamePage.routeName);
+            },
             child: Text(context.strings.playAgain),
           ),
         ],

--- a/lib/utils/audio_manager.dart
+++ b/lib/utils/audio_manager.dart
@@ -40,12 +40,14 @@ class AudioManager {
     await FlameAudio.audioCache.loadAll(fileNames);
   }
 
-  /// Plays a single sound effect located at [fileName]. The [position] decides
-  /// how loud the sound should be depending on its distance to the screen
-  /// centre. Optional [baseVolume] can be used to further tune the volume.
-  static Future<void> play(String fileName, Vector2 position,
-      {double baseVolume = 1}) async {
-    final volume = _volumeFor(position) * baseVolume;
+  /// Plays a single sound effect located at [fileName]. If [position] is
+  /// provided, the volume will be adjusted based on its distance from the
+  /// screen centre. Optional [baseVolume] can be used to further tune the
+  /// volume.
+  static Future<void> play(String fileName,
+      {Vector2? position, double baseVolume = 1}) async {
+    final volume =
+        (position != null ? _volumeFor(position) : 1) * baseVolume;
     await FlameAudio.play(fileName, volume: volume);
   }
 

--- a/lib/utils/game_sounds.dart
+++ b/lib/utils/game_sounds.dart
@@ -1,6 +1,8 @@
 import 'package:flame/extensions.dart';
 import 'package:humanity_vs_nature/generated/assets.dart';
-import 'package:humanity_vs_nature/utils/audio_manager.dart';
+import 'audio_manager.dart';
+
+export 'audio_manager.dart';
 
 class GameSounds {
   GameSounds._();


### PR DESCRIPTION
## Summary
- trigger tree, farm, city and field sounds on relevant actions
- add bulldozer spawn, tap and destruction audio cues
- play button and tutorial sounds across UI overlays
- export AudioManager via GameSounds and make positional audio optional
- simplify bulldozer audio by removing experimental movement loop

## Testing
- ❌ `flutter analyze` *(command not found)*
- ❌ `dart analyze` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689df5701dbc832d97beb3cdcd2e3bfa