### PR TITLE
Preload audio before showing main menu

### DIFF
--- a/lib/game/simulation_game.dart
+++ b/lib/game/simulation_game.dart
@@ -24,7 +24,6 @@ import 'package:humanity_vs_nature/generated/l10n.dart';
 import 'package:humanity_vs_nature/pages/overlays/game_interface_overlay.dart';
 import 'package:humanity_vs_nature/pages/overlays/lost_overlay.dart';
 import 'package:humanity_vs_nature/pages/overlays/win_overlay.dart';
-import 'package:humanity_vs_nature/utils/game_sounds.dart';
 import 'package:humanity_vs_nature/utils/game_sprites.dart';
 
 class SimulationGame extends FlameGame
@@ -63,7 +62,6 @@ class SimulationGame extends FlameGame
     await Future.delayed(const Duration(seconds: 1));
 
     AudioManager.initialize(this);
-    await GameSounds.preload();
     await GameSprites.preload();
 
     matrix = BlocksMatrix(worldSize);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,12 +3,18 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:humanity_vs_nature/generated/l10n.dart';
 import 'package:humanity_vs_nature/pages/game_page.dart';
 import 'package:humanity_vs_nature/pages/main_menu_page.dart';
+import 'package:flame_audio/flame_audio.dart';
+import 'package:humanity_vs_nature/utils/game_sounds.dart';
 import 'package:humanity_vs_nature/utils/prefs.dart';
 import 'package:humanity_vs_nature/utils/theme.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Prefs.init();
+  FlameAudio.audioCache.prefix = '';
+  await Future.wait([
+    Prefs.init(),
+    GameSounds.preload(),
+  ]);
 
   runApp(App());
 }


### PR DESCRIPTION
## Summary
- Initialize FlameAudio and preload GameSounds before rendering the main menu
- Remove redundant GameSounds preload from `SimulationGame`

## Testing
- `flutter analyze` *(fails: command not found)*
- `sudo apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689e07be7078832dbab16915322a09bd