### PR TITLE
Refactor naming for clarity

### DIFF
--- a/lib/game/modules/bulldozer/bulldozer_component.dart
+++ b/lib/game/modules/bulldozer/bulldozer_component.dart
@@ -30,8 +30,8 @@ class BulldozerComponent extends SpriteComponent
 
   final CityComponent city;
 
-  double hp = 7;
-  int killCount = 0;
+  double healthPoints = 7;
+  int treesDestroyed = 0;
   TreeComponent? targetTree;
   bool isReturningToBase = false;
   bool isAngry = false;
@@ -70,7 +70,7 @@ class BulldozerComponent extends SpriteComponent
     if (target != null) {
       if (position.distanceTo(target.position) < workingDistance) {
         if (target.doDamage(damagePerSecond * dt)) {
-          if (++killCount >= (isAngry ? killTarget * 2 : killTarget)) goHome();
+          if (++treesDestroyed >= (isAngry ? killTarget * 2 : killTarget)) goHome();
         }
       } else {
         goToPosition(target.position, workingDistance, dt);
@@ -101,7 +101,7 @@ class BulldozerComponent extends SpriteComponent
     } else if (other is BulldozerComponent) {
       final collisionVector = position - other.position;
       position += collisionVector * 0.1;
-      hp -= 0.1;
+      healthPoints -= 0.1;
     }
   }
 
@@ -112,16 +112,16 @@ class BulldozerComponent extends SpriteComponent
       GameSounds.bulldozerTapped(),
       position: event.canvasPosition,
     );
-    hp -= 1;
-    if (hp < 1) game.bulldozerModule.removeBulldozer(this);
+    healthPoints -= 1;
+    if (healthPoints < 1) game.bulldozerModule.removeBulldozer(this);
     animateOnTap();
   }
 
   void _updateTargetTree() {
     if (targetTree == null || targetTree?.isMounted == false) {
       final tree = isAngry
-          ? game.treeModule.findFreeNearestTree(city.position)
-          : game.treeModule.findFreeMatureNearestTree(position);
+          ? game.treeModule.findNearestFreeTree(city.position)
+          : game.treeModule.findNearestFreeMatureTree(position);
       targetTree = tree != targetTree && tree?.isMounted == true ? tree : null;
       state = VehicleState.stop;
     }

--- a/lib/game/modules/city/city_component.dart
+++ b/lib/game/modules/city/city_component.dart
@@ -272,7 +272,7 @@ class CityComponent extends SpriteComponent
               game.treeModule.trees.length) {
         final farm = forFarm;
         if (farm != null) {
-          final tree = game.treeModule.findFreeMatureNearestTree(farm.position);
+          final tree = game.treeModule.findNearestFreeMatureTree(farm.position);
           bulldozers.add(game.bulldozerModule.addBulldozer(this, target: tree));
         } else {
           bulldozers.add(game.bulldozerModule.addBulldozer(this));

--- a/lib/game/modules/tree/tree_module.dart
+++ b/lib/game/modules/tree/tree_module.dart
@@ -11,16 +11,16 @@ import 'package:humanity_vs_nature/utils/game_sounds.dart';
 class TreeModule extends Component with HasGameRef<SimulationGame> {
   final List<TreeComponent> trees = [];
 
-  TreeComponent? topmostTreeAddedDuringThisUpdate;
+  TreeComponent? _treePendingSorting;
 
   Iterable<Spot> get spots => trees.map((e) => e.spot);
 
   @override
   void update(double dt) {
-    final topmostTree = topmostTreeAddedDuringThisUpdate;
-    if (topmostTree != null) {
-      sortTreesByY(topmostTree);
-      topmostTreeAddedDuringThisUpdate = null;
+    final pendingTree = _treePendingSorting;
+    if (pendingTree != null) {
+      _sortTreesByVerticalPosition(pendingTree);
+      _treePendingSorting = null;
     }
     super.update(dt);
   }
@@ -65,7 +65,7 @@ class TreeModule extends Component with HasGameRef<SimulationGame> {
     trees.add(tree);
     add(tree);
     game.matrix.markBlocksForSpot(tree.spot, BlockType.tree);
-    updateTopmostTree(tree);
+    _markTreeForSorting(tree);
     AudioManager.play(
       isMature ? GameSounds.treeSpawned() : GameSounds.coneSpawned(),
       position: position,
@@ -82,18 +82,18 @@ class TreeModule extends Component with HasGameRef<SimulationGame> {
     game.matrix.markBlocksForSpot(tree.spot, BlockType.empty);
   }
 
-  void updateTopmostTree(TreeComponent tree) {
-    final topmostTree = topmostTreeAddedDuringThisUpdate;
-    if (topmostTree != null) {
-      if (tree.position.y > topmostTree.position.y) {
-        topmostTreeAddedDuringThisUpdate = tree;
+  void _markTreeForSorting(TreeComponent tree) {
+    final currentTree = _treePendingSorting;
+    if (currentTree != null) {
+      if (tree.position.y > currentTree.position.y) {
+        _treePendingSorting = tree;
       }
     } else {
-      topmostTreeAddedDuringThisUpdate = tree;
+      _treePendingSorting = tree;
     }
   }
 
-  void sortTreesByY(TreeComponent tree) {
+  void _sortTreesByVerticalPosition(TreeComponent tree) {
     trees.sort((a, b) => a.position.y.compareTo(b.position.y));
     final allTreesBelow = trees.where((e) => e.position.y > tree.position.y);
     removeWhere((e) => e is TreeComponent && e.position.y > tree.position.y);
@@ -154,7 +154,7 @@ class TreeModule extends Component with HasGameRef<SimulationGame> {
     );
   }
 
-  TreeComponent? findFreeNearestTree(
+  TreeComponent? findNearestFreeTree(
     Vector2 targetPosition, [
     List<TreeComponent>? treeList,
   ]) {
@@ -172,8 +172,8 @@ class TreeModule extends Component with HasGameRef<SimulationGame> {
     return findNearestTree(targetPosition, freeTrees);
   }
 
-  TreeComponent? findFreeMatureNearestTree(Vector2 targetPosition) {
-    return findFreeNearestTree(
+  TreeComponent? findNearestFreeMatureTree(Vector2 targetPosition) {
+    return findNearestFreeTree(
       targetPosition,
       trees.where((tree) => tree.isMature).toList(),
     );

--- a/lib/game/playing_field.dart
+++ b/lib/game/playing_field.dart
@@ -14,8 +14,8 @@ class PlayingField extends RectangleComponent
   static const double maxTreeSpawnTime = 10;
   static const Color grassColor = Colors.lightGreen;
 
-  var _timeForSpawnTree = 0.0;
-  Vector2? _preferredPositionForSpawnTree;
+  var _treeSpawnTimer = 0.0;
+  Vector2? _preferredTreeSpawnPosition;
 
   @override
   FutureOr<void> onLoad() {
@@ -29,7 +29,7 @@ class PlayingField extends RectangleComponent
   @override
   void update(double dt) {
     super.update(dt);
-    _trySpawnTree(dt);
+    _spawnTreeIfReady(dt);
   }
 
   @override
@@ -44,16 +44,16 @@ class PlayingField extends RectangleComponent
         GameSounds.grassTapped(),
         position: tapPosition,
       );
-      _timeForSpawnTree /= 2;
-      _preferredPositionForSpawnTree = tapPosition;
+      _treeSpawnTimer /= 2;
+      _preferredTreeSpawnPosition = tapPosition;
     }
   }
 
-  void _trySpawnTree(double dt) {
-    _timeForSpawnTree -= dt;
-    if (_timeForSpawnTree < 0) {
-      _timeForSpawnTree = randomFallback.nextDouble() * maxTreeSpawnTime;
-      final targetPosition = _preferredPositionForSpawnTree ??
+  void _spawnTreeIfReady(double dt) {
+    _treeSpawnTimer -= dt;
+    if (_treeSpawnTimer < 0) {
+      _treeSpawnTimer = randomFallback.nextDouble() * maxTreeSpawnTime;
+      final targetPosition = _preferredTreeSpawnPosition ??
           Vector2(
             size.x * randomFallback.nextDouble(),
             size.y * randomFallback.nextDouble(),
@@ -66,7 +66,7 @@ class PlayingField extends RectangleComponent
       if (treePosition != null) {
         game.treeModule.addTree(treePosition);
       }
-      _preferredPositionForSpawnTree = null;
+      _preferredTreeSpawnPosition = null;
     }
   }
 }

--- a/lib/game/simulation_game.dart
+++ b/lib/game/simulation_game.dart
@@ -30,7 +30,7 @@ class SimulationGame extends FlameGame
     with HasCollisionDetection, TapCallbacks, DragCallbacks, ScaleDetector {
   static const gameBackgroundColor = Colors.lightBlueAccent;
   static const double blockSize = 10;
-  static const double timeToStopCountdown = 30.1;
+  static const double initialLossCountdown = 30.1;
 
   late BlocksMatrix matrix;
 
@@ -55,7 +55,7 @@ class SimulationGame extends FlameGame
   final ValueNotifier<int> awarenessPercentage = ValueNotifier(0);
   final ValueNotifier<int> countdownToLoss = ValueNotifier(0);
 
-  double timerToLoss = timeToStopCountdown;
+  double lossCountdown = initialLossCountdown;
 
   @override
   FutureOr<void> onLoad() async {
@@ -111,15 +111,15 @@ class SimulationGame extends FlameGame
       overlays.add(WinOverlay.overlayName);
     } else {
       if (pollutionPercentage.value >= 100) {
-        timerToLoss -= dt;
-        if (timerToLoss <= 0) {
+        lossCountdown -= dt;
+        if (lossCountdown <= 0) {
           paused = true;
           overlays.add(LostOverlay.overlayName);
         }
       } else {
-        timerToLoss = timeToStopCountdown;
+        lossCountdown = initialLossCountdown;
       }
-      countdownToLoss.value = timerToLoss.ceil();
+      countdownToLoss.value = lossCountdown.ceil();
     }
   }
 


### PR DESCRIPTION
## Summary
- improve tree spawning variable and method names
- clarify loss countdown tracking in `SimulationGame`
- streamline tree module sorting and search helper names
- rename bulldozer health and kill counters for readability
- update city component for new tree search method

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a01f18c840832db13a22d306069b99