### PR TITLE
Add check script to handle missing Dart and Flutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@ An arcade game where you plant trees to fight global warming and restore wildlif
 
 You can download the APK (Android build) for the latest version of the game from this Google Drive link:
 https://drive.google.com/file/d/1M1etveS7DGxtZrdDHZLCTxLcVDJEyrob/view?usp=sharing
+
+## Development
+
+Run `./tool/run_checks.sh` to analyze the project and execute tests. The script
+skips steps gracefully when Dart or Flutter are not installed.

--- a/tool/run_checks.sh
+++ b/tool/run_checks.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+exit_code=0
+
+if command -v dart >/dev/null 2>&1; then
+  echo 'Running dart analyze'
+  if ! dart analyze; then
+    exit_code=1
+  fi
+else
+  echo 'Dart is not installed; skipping analysis.'
+fi
+
+if command -v flutter >/dev/null 2>&1; then
+  echo 'Running flutter test'
+  if ! flutter test; then
+    exit_code=1
+  fi
+else
+  echo 'Flutter is not installed; skipping tests.'
+fi
+
+exit $exit_code


### PR DESCRIPTION
## Summary
- add `tool/run_checks.sh` to gracefully skip analysis and tests when Dart or Flutter are missing
- document development check script in the README

## Testing
- `./tool/run_checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a02218c8ec832d92968f147567da80