### PR TITLE
Rename ContextExt extension for PositionComponent

### DIFF
--- a/lib/extensions/sprite_component_extension.dart
+++ b/lib/extensions/sprite_component_extension.dart
@@ -1,6 +1,6 @@
 import 'package:flame/components.dart';
 
-extension ContextExt on PositionComponent {
+extension PositionComponentExt on PositionComponent {
   bool isOutOfScreen(Vector2 screenSize) =>
       position.x - width / 2 > screenSize.x ||
       position.x + width / 2 < 0 ||


### PR DESCRIPTION
## Summary
- rename PositionComponent extension to `PositionComponentExt`

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a025c8c17c832d99d560608ba1c067